### PR TITLE
(chore) Remove '.manage.py test' from script section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ python:
 before_install:
   - "pip install -r requirements.txt"
 script:
-  - ./manage.py test
   - coverage run --omit="*virtualenv*","limber*","app/migrations/*" manage.py test
 branches:
   only:


### PR DESCRIPTION
- Removed "./manage.py test" script entry to eliminate duplication of test execution on Travis CI
