### PR TITLE
[#111942963] Create HTML format project invitation email

### DIFF
--- a/app/invite_email.py
+++ b/app/invite_email.py
@@ -2,76 +2,55 @@ html_email = """
 <!DOCTYPE html>
 <html>
 <head>
-	<title>Project Invitation</title>
-	<style type="text/css">
-
-		body {
-			font-family: Arial;
-			font-size: 1.5em;
-			text-align: left;
-		}
-
-		span {
-			background-color: #e0e0e0;
-		}
-
-		a {
-			border: 1px solid #2196F3;
-			padding: 1.2em 1.5em;
-			margin: 1em auto;
-			background: #2196F3;
-			border-radius: 3px;
-			color: #fff;
-			display: inline-block;
-			text-decoration: none;
-		}
-
-		a:hover {
-			cursor: pointer;
-		}
-
-		#main {
-			margin: auto;
-			padding: 2em;
-			width: 55em;
-			border-style: solid;
-			border-color: #80d8ff;
-		}
-
-		#url{
-			text-align: center;
-		}
-
-		img {
-			width: 3em;
-			height: 3em;
-		}
-
-		#letter_head img {
-			display: block;
-			margin: 0 auto;
-			padding-bottom: 1em;
-		}
-	</style>
+	<title></title>
 </head>
 <body>
-	<div id="main">
-		<div id="letter_head">
-			<img src="https://github.com/andela/limber/blob/develop/static/images/logo.png?raw=true">
-		</div>
-		<p id="salutation">Hi there,</p>
-		<p> <strong>%s</strong> has invited you to collaborate on project <span>%s</span> on Limber.</p>
-		<p>Limber is a project management platform for Agile perfectionists with deadlines.</p>
-		<p>To accept this invitation, click on the button below.</p>
-
-		<div id="url">
-			<a href=%s >Accept Invite</a>
-		</div>
-
-		<p>If you have received this email in error, please ignore it.</p>
-		<p>Thanks!</p>
-		<p>- The Limber Team.</p>
-	</div>
+	<table cellpadding="0" cellspacing="0" style="border-radius:4px;border:1px #dceaf5 solid" border="0" align="center">
+		<tbody>
+			<tr>
+				<td colspan="3" height="6"></td>
+			</tr>
+			<tr style="line-height:0px">
+				<td width="100%" style="font-size:0px" align="center" height="1">
+					<img width="40px" style="max-height:73px;width:40px" alt="" src="https://github.com/andela/limber/blob/develop/public/static/images/logo.png?raw=true" class="CToWUd">
+				</td>
+			</tr>
+			<tr>
+				<td>
+					<table cellpadding="0" cellspacing="0" style="line-height:25px" border="0" align="center">
+						<tbody>
+							<tr>
+								<td colspan="3" height="30"></td>
+							</tr>
+							<tr>
+								<td width="36"></td>
+								<td width="454" align="left" style="color:#444444;border-collapse:collapse;font-size:11pt;font-family:proxima_nova,'Open Sans','Lucida Grande','Segoe UI',Arial,Verdana,'Lucida Sans Unicode',Tahoma,'Sans Serif';max-width:454px" valign="top">
+									Hi there,
+									<br><br><b>{}</b> has invited you to collaborate on project <span class="il">{}</span> on Limber.
+									<span class="il">Limber</span> is a project management platform for Agile perfectionists with deadlines.
+									<br>
+									<br>
+									<span>To accept this invitation, click on the button below.</span>
+									<br>
+									<br>
+									<center>
+										<a style="border-radius:3px;font-size:15px;color:white;border:1px #1373b5 solid;text-decoration:none;padding:14px 7px 14px 7px;width:280px;max-width:280px;font-family:proxima_nova,'Open Sans','lucida grande','Segoe UI',arial,verdana,'lucida sans unicode',tahoma,sans-serif;margin:6px auto;display:block;background-color:#007ee6;text-align:center" href={} target="_blank">Accept invite</a></center>
+									<br>
+									<span>Thanks!</span>
+									<br>
+									<span>- The <span class="il">Limber</span> Team</span>
+								</td>
+								<td width="36"></td>
+							</tr>
+							<tr>
+								<td colspan="3" height="36"></td>
+							</tr>
+						</tbody>
+					</table>
+				</td>
+			</tr>
+		</tbody>
+	</table>
 </body>
 </html>
 """

--- a/app/invite_email.py
+++ b/app/invite_email.py
@@ -1,0 +1,77 @@
+html_email = """
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Project Invitation</title>
+	<style type="text/css">
+
+		body {
+			font-family: Arial;
+			font-size: 1.5em;
+			text-align: left;
+		}
+
+		span {
+			background-color: #e0e0e0;
+		}
+
+		a {
+			border: 1px solid #2196F3;
+			padding: 1.2em 1.5em;
+			margin: 1em auto;
+			background: #2196F3;
+			border-radius: 3px;
+			color: #fff;
+			display: inline-block;
+			text-decoration: none;
+		}
+
+		a:hover {
+			cursor: pointer;
+		}
+
+		#main {
+			margin: auto;
+			padding: 2em;
+			width: 55em;
+			border-style: solid;
+			border-color: #80d8ff;
+		}
+
+		#url{
+			text-align: center;
+		}
+
+		img {
+			width: 3em;
+			height: 3em;
+		}
+
+		#letter_head img {
+			display: block;
+			margin: 0 auto;
+			padding-bottom: 1em;
+		}
+	</style>
+</head>
+<body>
+	<div id="main">
+		<div id="letter_head">
+			<img src="https://github.com/andela/limber/blob/develop/static/images/logo.png?raw=true">
+		</div>
+		<p id="salutation">Hi there,</p>
+		<p> <strong>%s</strong> has invited you to collaborate on project <span>%s</span> on Limber.</p>
+		<p>Limber is a project management platform for Agile perfectionists with deadlines.</p>
+		<p>To accept this invitation, click on the button below.</p>
+
+		<div id="url">
+			<a href=%s >Accept Invite</a>
+		</div>
+
+		<p>If you have received this email in error, please ignore it.</p>
+		<p>Thanks!</p>
+		<p>- The Limber Team.</p>
+	</div>
+</body>
+</html>
+"""

--- a/app/models/invite.py
+++ b/app/models/invite.py
@@ -56,12 +56,11 @@ class ProjectInvite(models.Model):
 				If you have received this in error, please let us know.
 				""".format(self.project.project_name, url)
 
-		html_content = html_email % (
+		html_content = html_email.format(
 			self.uid.profile.username,
 			self.project.project_name,
 			url
 		)
-
 		email = EmailMultiAlternatives(
 			'Invitation to collaborate on project ' + self.project.project_name,
 			body,

--- a/app/models/invite.py
+++ b/app/models/invite.py
@@ -7,10 +7,11 @@ from random import random
 from django.db import models
 from django.core import mail
 from django.core.urlresolvers import reverse
-from django.core.mail import EmailMessage
+from django.core.mail import EmailMultiAlternatives
 
 from .project import Project
 from .user import UserAuthentication
+from app.invite_email import html_email
 
 
 class ProjectInvite(models.Model):
@@ -54,13 +55,21 @@ class ProjectInvite(models.Model):
 				\n\n\n
 				If you have received this in error, please let us know.
 				""".format(self.project.project_name, url)
-		email = EmailMessage(
+
+		html_content = html_email % (
+			self.uid.profile.username,
+			self.project.project_name,
+			url
+		)
+
+		email = EmailMultiAlternatives(
 			'Invitation to collaborate on project ' + self.project.project_name,
 			body,
 			self.uid.email,
 			[self.email],
 			connection=connection
 		)
+		email.attach_alternative(html_content, 'text/html')
 		# send the email then save the invite to the database
 		email.send()
 

--- a/app/templates/email.html
+++ b/app/templates/email.html
@@ -1,75 +1,13 @@
-<!DOCTYPE html>
+<<!DOCTYPE html>
 <html>
 <head>
-	<title>Project Invitation</title>
-	<style type="text/css">
-
-		body {
-			font-family: Arial;
-			font-size: 1.5em;
-			text-align: left;
-		}
-
-		span {
-			background-color: #e0e0e0;
-		}
-
-		a {
-			border: 1px solid #2196F3;
-			padding: 1.2em 1.5em;
-			margin: 1em auto;
-			background: #2196F3;
-			border-radius: 3px;
-			color: #fff;
-			display: inline-block;
-			text-decoration: none;
-		}
-
-		a:hover {
-			cursor: pointer;
-		}
-
-		#main {
-			margin: auto;
-			padding: 2em;
-			width: 55em;
-			border-style: solid;
-			border-color: #80d8ff;
-		}
-
-		#url{
-			text-align: center;
-		}
-
-		img {
-			width: 3em;
-			height: 3em;
-		}
-
-		#letter_head img {
-			display: block;
-			margin: 0 auto;
-			padding-bottom: 1em;
-		}
-	</style>
+	<title></title>
 </head>
 <body>
-	<div id="main">
-		<div id="letter_head">
-			<img src="https://github.com/andela/limber/blob/develop/static/images/logo.png?raw=true">
-		</div>
-		<p id="salutation">Hi there,</p>
-		<p> <strong>%s</strong> has invited you to collaborate on project <span>%s</span> on Limber.</p>
-		<p>Limber is a project management platform for Agile perfectionists with deadlines.</p>
-		<p>To accept this invitation, click on the button below.</p>
-
-		<div id="url">
-			<a href=%s >Accept Invite</a>
-		</div>
-
-		<p>If you have received this email in error, please ignore it.</p>
-		<p>Thanks!</p>
-		<p>- The Limber Team.</p>
-	</div>
+	<table cellpadding="0" cellspacing="0" style="border-radius:4px;border:1px #dceaf5 solid" border="0" align="center"><tbody><tr><td colspan="3" height="6"></td></tr><tr style="line-height:0px"><td width="100%" style="font-size:0px" align="center" height="1"><img width="40px" style="max-height:73px;width:40px" alt="" src="https://github.com/andela/limber/blob/develop/public/static/images/logo.png?raw=true" class="CToWUd"></td></tr><tr><td><table cellpadding="0" cellspacing="0" style="line-height:25px" border="0" align="center"><tbody><tr><td colspan="3" height="30"></td></tr><tr><td width="36"></td>
+<td width="454" align="left" style="color:#444444;border-collapse:collapse;font-size:11pt;font-family:proxima_nova,'Open Sans','Lucida Grande','Segoe UI',Arial,Verdana,'Lucida Sans Unicode',Tahoma,'Sans Serif';max-width:454px" valign="top">Hi there,<br><br><b>%s</b> has invited you to collaborate on project <span class="il">%s</span> on Limber. <span class="il">Limber</span> is a project management platform for Agile perfectionists with deadlines.<br><br>To accept this invitation, click on the button below.<br><br><center><a style="border-radius:3px;font-size:15px;color:white;border:1px #1373b5 solid;text-decoration:none;padding:14px 7px 14px 7px;width:280px;max-width:280px;font-family:proxima_nova,'Open Sans','lucida grande','Segoe UI',arial,verdana,'lucida sans unicode',tahoma,sans-serif;margin:6px auto;display:block;background-color:#007ee6;text-align:center" href=%s target="_blank">Accept invite</a></center>
+<br>Thanks!<br>- The <span class="il">Limber</span> Team</td>
+<td width="36"></td>
+</tr><tr><td colspan="3" height="36"></td></tr></tbody></table></td></tr></tbody></table>
 </body>
 </html>

--- a/app/templates/email.html
+++ b/app/templates/email.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Project Invitation</title>
+	<style type="text/css">
+
+		body {
+			font-family: Arial;
+			font-size: 1.5em;
+			text-align: left;
+		}
+
+		span {
+			background-color: #e0e0e0;
+		}
+
+		a {
+			border: 1px solid #2196F3;
+			padding: 1.2em 1.5em;
+			margin: 1em auto;
+			background: #2196F3;
+			border-radius: 3px;
+			color: #fff;
+			display: inline-block;
+			text-decoration: none;
+		}
+
+		a:hover {
+			cursor: pointer;
+		}
+
+		#main {
+			margin: auto;
+			padding: 2em;
+			width: 55em;
+			border-style: solid;
+			border-color: #80d8ff;
+		}
+
+		#url{
+			text-align: center;
+		}
+
+		img {
+			width: 3em;
+			height: 3em;
+		}
+
+		#letter_head img {
+			display: block;
+			margin: 0 auto;
+			padding-bottom: 1em;
+		}
+	</style>
+</head>
+<body>
+	<div id="main">
+		<div id="letter_head">
+			<img src="https://github.com/andela/limber/blob/develop/static/images/logo.png?raw=true">
+		</div>
+		<p id="salutation">Hi there,</p>
+		<p> <strong>%s</strong> has invited you to collaborate on project <span>%s</span> on Limber.</p>
+		<p>Limber is a project management platform for Agile perfectionists with deadlines.</p>
+		<p>To accept this invitation, click on the button below.</p>
+
+		<div id="url">
+			<a href=%s >Accept Invite</a>
+		</div>
+
+		<p>If you have received this email in error, please ignore it.</p>
+		<p>Thanks!</p>
+		<p>- The Limber Team.</p>
+	</div>
+</body>
+</html>


### PR DESCRIPTION
- Used EmailMultiAlternative class that subclasses EmailMessage to send project invitation in HTML format
- Created module 'invite_email.py' that contains the email (in markup) as a string. This is then imported into 'invite.py' and conversion specifiers replace the placeholders for invitor, project name and invitation url.
- Created the 'email.html' file to render the invitation email on browser during development
