### PR TITLE
#112311313 Creating and managing projects on dashboard

### DIFF
--- a/app/urls.py
+++ b/app/urls.py
@@ -23,6 +23,11 @@ router.register(
 	'project-invites'
 )
 router.register(
+	r'org-admin-associations',
+	viewsets.OrgAdminAssociationViewSet,
+	'org-admin-associations'
+)
+router.register(
 	r'org-associations',
 	viewsets.OrgAssociationViewSet,
 	'org-associations'

--- a/app/viewsets.py
+++ b/app/viewsets.py
@@ -498,8 +498,8 @@ class ProjectInviteViewSet(viewsets.ModelViewSet):
 			)
 
 
-class OrgAssociationViewSet(viewsets.ReadOnlyModelViewSet):
-	"""API endpoint to list all organisations associated with the current user."""
+class OrgAdminAssociationViewSet(viewsets.ReadOnlyModelViewSet):
+	"""API endpoint to list all organisations in which current user is an admin."""
 
 	serializer_class = OrgSerializer
 	permission_classes = (permissions.IsAuthenticated,)
@@ -512,5 +512,20 @@ class OrgAssociationViewSet(viewsets.ReadOnlyModelViewSet):
 			user=current_user,
 			user_level=1
 		).values_list('org', flat=True)
+		org_objects = User.objects.filter(user_type=2, id__in=orgs, )
+		return org_objects
+
+
+class OrgAssociationViewSet(viewsets.ReadOnlyModelViewSet):
+	"""API endpoint to list all organisations in which current user is a member"""
+
+	serializer_class = OrgSerializer
+	permission_classes = (permissions.IsAuthenticated,)
+
+	def get_queryset(self):
+		"""Modify the queryset to fetch all organisations in which current user
+		is a member."""
+		current_user = self.request.user
+		orgs = Member.objects.filter(user=current_user).values_list('org', flat=True)
 		org_objects = User.objects.filter(user_type=2, id__in=orgs, )
 		return org_objects

--- a/public/static/scripts/controllers/projectCtrl.js
+++ b/public/static/scripts/controllers/projectCtrl.js
@@ -17,21 +17,34 @@ app.controller('ProjectCtrl', function($scope, $cookies, mainService){
     $scope.confirm = {};
 
     $scope.createPersonalProject = function () {
-    	mainService.Projects.createProject($scope.personal).$promise.then(
-    		function (response) {
-    			loadPersonalProjects()
-    			$scope.personal.project_name = '';
-    			$scope.personal.project_desc = '';
-    		},
-    		function (error) {
-    			console.log(error);
-    		}
-    	);
+
+        if ($scope.personal.project_name && $scope.personal.project_desc) {
+            $('#personalProjectModal').closeModal();
+            mainService.Projects.createProject($scope.personal).$promise.then(
+                function (response) {
+                    // refresh projects
+                    loadPersonalProjects()
+                    var $toastContent = $('<span style="font-weight: bold;">Personal project created.</span>');
+                    Materialize.toast($toastContent, 5000);
+                    // clear modal fields
+                    $scope.personal.project_name = '';
+                    $scope.personal.project_desc = '';
+                },
+                function (error) {
+                    var $toastContent = $('<span style="font-weight: bold;">An error occured while creating project.</span>');
+                    Materialize.toast($toastContent, 5000);
+                }
+            );
+        } else {
+            var $toastContent = $('<span style="font-weight: bold;">Please fill in both fields.</span>');
+            Materialize.toast($toastContent, 5000);
+        }
+
     };
 
     $scope.createOrganisationalProject = function () {
-
-        if ($scope.organisational.owner) {
+        if ($scope.organisational.owner && $scope.organisational.project_name && $scope.organisational.project_desc) {
+            $('#organisationalProjectModal').closeModal();
             mainService.Projects.createProject($scope.organisational).$promise.then(
                 function (response) {
                     var $toastContent = $('<span style="font-weight: bold;">Organisation project created.</span>');
@@ -47,9 +60,7 @@ app.controller('ProjectCtrl', function($scope, $cookies, mainService){
                 }
             );
         } else {
-            var $toastContent = $('<span style="font-weight: bold;">' +
-                '<p>You are creating an organisational project.</p>' +
-                '<p>Please specify the Organisation that owns this project</p></span>');
+            var $toastContent = $('<span style="font-weight: bold;"><p>Please fill all the fields.</p></span>');
             Materialize.toast($toastContent, 10000);
         }
 
@@ -74,31 +85,38 @@ app.controller('ProjectCtrl', function($scope, $cookies, mainService){
     };
 
     $scope.editProject = function(project_id) {
-        var data = {
-            project_id: $scope.edit_project_id,
-            owner: $scope.edit_project_owner_id,
-            project_name: $scope.edit.project_name,
-            project_desc: $scope.edit.project_desc
-        };
-        mainService.Projects.editProject(data).$promise.then(
-            function (response) {
-                var $toastContent = $('<span style="font-weight: bold;">Project details updated.</span>');
-                Materialize.toast($toastContent, 5000);
-                // reload page
-                if ($scope.edit_owner_type === 'personal') {
-                    loadPersonalProjects();
-                } else if ($scope.edit_owner_type === 'organisational') {
-                    loadOrgProjects();
+        if ($scope.edit.project_desc && $scope.edit.project_name) {
+            $('#editProjectModal').closeModal();
+            var data = {
+                project_id: $scope.edit_project_id,
+                owner: $scope.edit_project_owner_id,
+                project_name: $scope.edit.project_name,
+                project_desc: $scope.edit.project_desc
+            };
+            mainService.Projects.editProject(data).$promise.then(
+                function (response) {
+                    var $toastContent = $('<span style="font-weight: bold;">Project details updated.</span>');
+                    Materialize.toast($toastContent, 5000);
+                    // reload page
+                    if ($scope.edit_owner_type === 'personal') {
+                        loadPersonalProjects();
+                    } else if ($scope.edit_owner_type === 'organisational') {
+                        loadOrgProjects();
+                    }
+                    // Reset modal values
+                    $scope.edit.project_name = '';
+                    $scope.edit.project_desc = '';
+                },
+                function (error) {
+                    var $toastContent = $('<span style="font-weight: bold;">Error! Project not updated.</span>');
+                    Materialize.toast($toastContent, 5000);
                 }
-                // Reset modal values
-                $scope.edit.project_name = '';
-                $scope.edit.project_desc = '';
-            },
-            function (error) {
-                var $toastContent = $('<span style="font-weight: bold;">Error! Project not updated.</span>');
-                Materialize.toast($toastContent, 5000);
-            }
-        );
+            );
+        } else {
+            var $toastContent = $('<span style="font-weight: bold;"><p>Please fill all the fields.</p></span>');
+            Materialize.toast($toastContent, 10000);
+        }
+
     };
 
     $scope.openDeleteModal = function (project_id, owner_type) {

--- a/public/static/scripts/controllers/projectCtrl.js
+++ b/public/static/scripts/controllers/projectCtrl.js
@@ -21,7 +21,6 @@ app.controller('ProjectCtrl', function($scope, $cookies, mainService){
                 // $scope.org_projects = response;
                 // console.log("One" + org_id, $scope.org_projects);
                 $scope.orgProjectClassifier[org_id] = response;
-                console.log($scope.orgProjectClassifier);
             },
             function (error) {
                 console.log(error);
@@ -33,7 +32,6 @@ app.controller('ProjectCtrl', function($scope, $cookies, mainService){
     var loadUserOrganisations = function() {
         // load all the organisations in which current user belongs
         $scope.user_organisations = mainService.OrgAssociations.getAll();
-        console.log($scope.user_organisations);
 
         // console.log($scope.user_organisations.length);
     }
@@ -80,7 +78,7 @@ app.controller('ProjectCtrl', function($scope, $cookies, mainService){
                     var $toastContent = $('<span style="font-weight: bold;">Organisation project created.</span>');
                     Materialize.toast($toastContent, 5000);
                     // Refresh view
-                    loadOrgProjects();
+                    loadUserOrganisations();
                     //  Clear data in modal
                     $scope.organisational = {};
                 },
@@ -131,7 +129,7 @@ app.controller('ProjectCtrl', function($scope, $cookies, mainService){
                     if ($scope.edit_owner_type === 'personal') {
                         loadPersonalProjects();
                     } else if ($scope.edit_owner_type === 'organisational') {
-                        loadOrgProjects();
+                        loadUserOrganisations();
                     }
                     // Reset modal values
                     $scope.edit.project_name = '';
@@ -167,7 +165,7 @@ app.controller('ProjectCtrl', function($scope, $cookies, mainService){
                     if ($scope.delete_owner_type === 'personal') {
                         loadPersonalProjects();
                     } else if ($scope.delete_owner_type === 'organisational') {
-                        loadOrgProjects();
+                        loadUserOrganisations();
                     }
                     // clear modal field on success
                     $scope.confirm.delete = '';

--- a/public/static/scripts/controllers/projectCtrl.js
+++ b/public/static/scripts/controllers/projectCtrl.js
@@ -12,14 +12,11 @@ app.controller('ProjectCtrl', function($scope, $cookies, mainService){
     $scope.loadOrgProjects = function (org_id) {
         // Provide the owner_id query parameter. This returns projects that belong
         // to organisations of this org_id
-
         var data = {
             owner_id: org_id
         }
         mainService.org.getProjects(data).$promise.then(
             function (response) {
-                // $scope.org_projects = response;
-                // console.log("One" + org_id, $scope.org_projects);
                 $scope.orgProjectClassifier[org_id] = response;
             },
             function (error) {
@@ -27,13 +24,10 @@ app.controller('ProjectCtrl', function($scope, $cookies, mainService){
             }
         );
     };
-    // loadOrgProjects();
 
     var loadUserOrganisations = function() {
         // load all the organisations in which current user belongs
         $scope.user_organisations = mainService.OrgAssociations.getAll();
-
-        // console.log($scope.user_organisations.length);
     }
     loadUserOrganisations();
 
@@ -45,27 +39,23 @@ app.controller('ProjectCtrl', function($scope, $cookies, mainService){
     $scope.confirm = {};
 
     $scope.createPersonalProject = function () {
-
         if ($scope.personal.project_name && $scope.personal.project_desc) {
             $('#personalProjectModal').closeModal();
             mainService.Projects.createProject($scope.personal).$promise.then(
                 function (response) {
                     // refresh projects
-                    loadPersonalProjects()
-                    var $toastContent = $('<span style="font-weight: bold;">Personal project created.</span>');
-                    Materialize.toast($toastContent, 5000);
+                    loadPersonalProjects();
+                    Materialize.toast('Personal project created.', 5000);
                     // clear modal fields
                     $scope.personal.project_name = '';
                     $scope.personal.project_desc = '';
                 },
                 function (error) {
-                    var $toastContent = $('<span style="font-weight: bold;">An error occured while creating project.</span>');
-                    Materialize.toast($toastContent, 5000);
+                    Materialize.toast('An error occured while creating project.', 5000);
                 }
             );
         } else {
-            var $toastContent = $('<span style="font-weight: bold;">Please fill in both fields.</span>');
-            Materialize.toast($toastContent, 5000);
+            Materialize.toast('Please fill in both fields.', 5000);
         }
 
     };
@@ -75,21 +65,18 @@ app.controller('ProjectCtrl', function($scope, $cookies, mainService){
             $('#organisationalProjectModal').closeModal();
             mainService.Projects.createProject($scope.organisational).$promise.then(
                 function (response) {
-                    var $toastContent = $('<span style="font-weight: bold;">Organisation project created.</span>');
-                    Materialize.toast($toastContent, 5000);
+                    Materialize.toast('Organisation project created.', 5000);
                     // Refresh view
                     loadUserOrganisations();
                     //  Clear data in modal
                     $scope.organisational = {};
                 },
                 function (error) {
-                    var $toastContent = $('<span style="font-weight: bold;">Error! Organisation project not created.</span>');
-                    Materialize.toast($toastContent, 5000);
+                    Materialize.toast('Error! Organisation project not created.', 5000);
                 }
             );
         } else {
-            var $toastContent = $('<span style="font-weight: bold;"><p>Please fill all the fields.</p></span>');
-            Materialize.toast($toastContent, 10000);
+            Materialize.toast('Please fill all the fields.', 10000);
         }
 
     };
@@ -123,8 +110,7 @@ app.controller('ProjectCtrl', function($scope, $cookies, mainService){
             };
             mainService.Projects.editProject(data).$promise.then(
                 function (response) {
-                    var $toastContent = $('<span style="font-weight: bold;">Project details updated.</span>');
-                    Materialize.toast($toastContent, 5000);
+                    Materialize.toast('Project details updated.', 5000);
                     // reload page
                     if ($scope.edit_owner_type === 'personal') {
                         loadPersonalProjects();
@@ -136,13 +122,11 @@ app.controller('ProjectCtrl', function($scope, $cookies, mainService){
                     $scope.edit.project_desc = '';
                 },
                 function (error) {
-                    var $toastContent = $('<span style="font-weight: bold;">Error! Project not updated.</span>');
-                    Materialize.toast($toastContent, 5000);
+                    Materialize.toast('Error! Project not updated.', 5000);
                 }
             );
         } else {
-            var $toastContent = $('<span style="font-weight: bold;"><p>Please fill all the fields.</p></span>');
-            Materialize.toast($toastContent, 10000);
+            Materialize.toast('Please fill all the fields.', 10000);
         }
 
     };
@@ -160,8 +144,7 @@ app.controller('ProjectCtrl', function($scope, $cookies, mainService){
             };
             mainService.Projects.deleteProject(data).$promise.then(
                 function (response) {
-                    var $toastContent = $('<span style="font-weight: bold;">Project deleted.</span>');
-                    Materialize.toast($toastContent, 5000);
+                    Materialize.toast('Project deleted.', 5000);
                     if ($scope.delete_owner_type === 'personal') {
                         loadPersonalProjects();
                     } else if ($scope.delete_owner_type === 'organisational') {
@@ -171,14 +154,12 @@ app.controller('ProjectCtrl', function($scope, $cookies, mainService){
                     $scope.confirm.delete = '';
                 },
                 function (error) {
-                    var $toastContent = $('<span style="font-weight: bold;">Error! Project not deleted.</span>');
-                    Materialize.toast($toastContent, 5000);
+                    Materialize.toast('Error! Project not deleted.', 5000);
                 }
             );
 
         } else {
-            var $toastContent = $('<span style="font-weight: bold;">Please confirm this operation by typing DELETE.</span>');
-            Materialize.toast($toastContent, 5000);
+            Materialize.toast('Please confirm this operation by typing DELETE.', 5000);
         }
 
     };

--- a/public/static/scripts/controllers/projectCtrl.js
+++ b/public/static/scripts/controllers/projectCtrl.js
@@ -1,14 +1,44 @@
 app.controller('ProjectCtrl', function($scope, $cookies, mainService){
     $('.modal-trigger').leanModal();
 
+
+    $scope.orgProjectClassifier = {};
+
     var loadPersonalProjects = function () {
     	$scope.personal_projects = mainService.personal.getProjects();
     };
     loadPersonalProjects();
-    var loadOrgProjects = function () {
-    	$scope.org_projects = mainService.org.getProjects();
+
+    $scope.loadOrgProjects = function (org_id) {
+        // Provide the owner_id query parameter. This returns projects that belong
+        // to organisations of this org_id
+
+        var data = {
+            owner_id: org_id
+        }
+        mainService.org.getProjects(data).$promise.then(
+            function (response) {
+                // $scope.org_projects = response;
+                // console.log("One" + org_id, $scope.org_projects);
+                $scope.orgProjectClassifier[org_id] = response;
+                console.log($scope.orgProjectClassifier);
+            },
+            function (error) {
+                console.log(error);
+            }
+        );
     };
-    loadOrgProjects();
+    // loadOrgProjects();
+
+    var loadUserOrganisations = function() {
+        // load all the organisations in which current user belongs
+        $scope.user_organisations = mainService.OrgAssociations.getAll();
+        console.log($scope.user_organisations);
+
+        // console.log($scope.user_organisations.length);
+    }
+    loadUserOrganisations();
+
     $scope.other_projects = mainService.other.getProjects();
     $scope.personal = {};
     $scope.organisational = {};
@@ -66,8 +96,8 @@ app.controller('ProjectCtrl', function($scope, $cookies, mainService){
 
     };
 
-    $scope.getAssociatedOrgs = function () {
-    	mainService.OrgAssociations.getAll().$promise.then(
+    $scope.getAdminAssociatedOrgs = function () {
+    	mainService.OrgAdminAssociations.getAll().$promise.then(
     		function (response) {
     			$scope.org_associations = response;
     		},

--- a/public/static/scripts/services/mainService.js
+++ b/public/static/scripts/services/mainService.js
@@ -87,7 +87,7 @@ app.factory('mainService', function ($resource) {
         }, {
             stripTrailingSlashes: false
         }),
-        OrgAssociations: $resource('/api/org-associations/', {}, {
+        OrgAdminAssociations: $resource('/api/org-admin-associations/', {}, {
             getAll: {
                 method: 'GET',
                 isArray: true

--- a/public/static/scripts/services/mainService.js
+++ b/public/static/scripts/services/mainService.js
@@ -94,6 +94,14 @@ app.factory('mainService', function ($resource) {
             }
         }, {
             stripTrailingSlashes: false
+        }),
+        OrgAssociations: $resource('/api/org-associations/', {}, {
+            getAll: {
+                method: 'GET',
+                isArray: true
+            }
+        }, {
+            stripTrailingSlashes: false
         })
     };
 });

--- a/public/static/styles/style.css
+++ b/public/static/styles/style.css
@@ -153,9 +153,10 @@ h5 {
 }
 
 .add-project .card {
-    background: #e0e0e0;
+    /*background: #e0e0e0;*/
     min-height: 110px;
-    box-shadow: 0 2px 5px 0 #9e9e9e,0 2px 10px 0 #9e9e9e;
+    border: dashed #aaaaaa 1px;
+    /*box-shadow: 0 2px 5px 0 #9e9e9e,0 2px 10px 0 #9e9e9e;*/
 }
 
 .add-project .valign {
@@ -166,6 +167,7 @@ h5 {
     font-size: 20px;
     line-height: 1.5em;
     display: -webkit-box;
+    color: #888888;
 }
 
 .add-project span i{

--- a/public/templates/limber/projects.html
+++ b/public/templates/limber/projects.html
@@ -140,7 +140,7 @@
 			</div>
 			<div class="row">
 				<div class="input-field col s12">
-					<input ng-model="personal.project_name" id="personal_project_name" type="text" class="validate">
+					<input required ng-model="personal.project_name" id="personal_project_name" type="text" class="validate">
 					<label for="personal_project_name">Project Name</label>
 				</div>
 			</div>
@@ -152,7 +152,7 @@
 			</div>
 		</div>
 		<div class="modal-footer">
-			<a class="modal-action modal-close waves-effect waves-green btn-flat " ng-click="createPersonalProject()">Save</a>
+			<a class="modal-action waves-effect waves-green btn-flat " ng-click="createPersonalProject()">Save</a>
 			<a class="modal-action modal-close waves-effect waves-green btn-flat ">Cancel</a>
 		</div>
 	</div>
@@ -185,7 +185,7 @@
 			</div>
 		</div>
 		<div class="modal-footer">
-			<a class="modal-action modal-close waves-effect waves-green btn-flat " ng-click="createOrganisationalProject()">Save</a>
+			<a class="modal-action waves-effect waves-green btn-flat " ng-click="createOrganisationalProject()">Save</a>
 			<a class="modal-action modal-close waves-effect waves-green btn-flat ">Cancel</a>
 		</div>
 	</div>
@@ -209,7 +209,7 @@
 			</div>
 		</div>
 		<div class="modal-footer">
-			<a class="modal-action modal-close waves-effect waves-green btn-flat " ng-click="editProject()">Save Changes</a>
+			<a class="modal-action waves-effect waves-green btn-flat " ng-click="editProject()">Save Changes</a>
 			<a class="modal-action modal-close waves-effect waves-green btn-flat ">Cancel</a>
 		</div>
 	</div>

--- a/public/templates/limber/projects.html
+++ b/public/templates/limber/projects.html
@@ -91,21 +91,21 @@
 							</div>
 						</div>
 					</div>
-					<!-- Add organisational Project div -->
-					<div class="col s12 m4 l3 add-project">
-						<a href="#organisationalProjectModal" class="modal-trigger" ng-click="getAdminAssociatedOrgs()">
-							<div  class="card valign-wrapper">
-								<div class="card-content valign">
-									<span>
-										<i class="material-icons tiny">add</i> Add Project
-									</span>
-								</div>
-							</div>
-						</a>
-					</div>
 					<div ng-show="org_projects.length !== 0" class="col s12">
 						<a href="#">view all</a>
 					</div>
+				</div>
+				<!-- Add organisational Project div -->
+				<div class="col s12 m4 l3 add-project">
+					<a href="#organisationalProjectModal" class="modal-trigger" ng-click="getAdminAssociatedOrgs()">
+						<div  class="card valign-wrapper">
+							<div class="card-content valign">
+								<span>
+									<i class="material-icons tiny">add</i> Add Project
+								</span>
+							</div>
+						</div>
+					</a>
 				</div>
 
 				<!-- Other projects view -->

--- a/public/templates/limber/projects.html
+++ b/public/templates/limber/projects.html
@@ -7,8 +7,11 @@
 	<div class="row">
 		<div id="dash_wrapper" class="container">
 			<div class="row" >
+
+				<!-- Personal Projects -->
 				<div class="col s12">
 					<h5>Personal Projects</h5>
+
 					<div class="col s12 m4 l3" ng-repeat="project in personal_projects">
 						<div class="card">
 							<div class="card-content">
@@ -23,19 +26,20 @@
 								</div>
 							</div>
 							<div class="card-reveal">
-						     	<span class="card-title grey-text text-darken-4"><i class="material-icons right">close</i>Actions</span>
-						    	<div class="fixed-action-btn horizontal" style="bottom: 45px; right: 24px;">
-								    <a class="btn-floating btn-small btn-flat black">
-									    <i class="fa fa-list" style="font-size: 17px;"></i>
+						    <span class="card-title grey-text text-darken-4"><i class="material-icons right">close</i>Actions</span>
+						    <div class="fixed-action-btn horizontal" style="bottom: 45px; right: 24px;">
+								  <a class="btn-floating btn-small btn-flat black">
+									  <i class="fa fa-list" style="font-size: 17px;"></i>
 									</a>
 									<ul>
-									    <li><a class="btn-floating btn-small btn-flat red" ng-click="openDeleteModal(project.project_id, 'personal')"><i class="material-icons">delete</i></a></li>
-									    <li><a class="btn-floating btn-small btn-flat blue" ng-click="openEditProjectModal(project.project_id, project.owner, 'personal')"><i class="material-icons">edit</i></a></li>
+									  <li><a class="btn-floating btn-small btn-flat red" ng-click="openDeleteModal(project.project_id, 'personal')"><i class="material-icons">delete</i></a></li>
+									  <li><a class="btn-floating btn-small btn-flat blue" ng-click="openEditProjectModal(project.project_id, project.owner, 'personal')"><i class="material-icons">edit</i></a></li>
 									</ul>
 								</div>
 							</div>
 						</div>
 					</div>
+					<!-- Add personal project div -->
 					<div class="col s12 m4 l3 add-project">
 						<a href="#personalProjectModal" class="modal-trigger">
 							<div class="card valign-wrapper">
@@ -51,35 +55,43 @@
 						<a href="#">view all</a>
 					</div>
 				</div>
-				<div class="col s12">
-					<h5>Organization Projects</h5>
-					<div class="col s12 m4 l3" ng-repeat="project in org_projects">
-						<div class="card">
-							<div class="card-content">
-								<a class="card-title">
-									<i class="material-icons activator right">more_vert</i>
-									<!-- When a description is more than 14 characters, show the first 14
-									followed by three dots (cont) -->
-									[[ project.project_name.substring(0, 14) ]][[project.project_name.length > 14 ? "...": ""]]
-								</a>
-								<div class="word-wrap">
-									[[ project.project_desc.substring(0, 14) ]][[project.project_desc.length > 14 ? "...": ""]]
+
+				<!-- Organisational Projects -->
+				<br>
+				<h5>Organization Projects</h5>
+				<div class="col s12" ng-repeat="org in user_organisations">
+					<hr>
+					<p>[[ org.full_name]] </p>
+					<div ng-init="loadOrgProjects(org.org_id)">
+						<div class="col s12 m4 l3" ng-repeat="project in orgProjectClassifier[org.org_id]">
+							<div class="card">
+								<div class="card-content">
+									<a class="card-title">
+										<i class="material-icons activator right">more_vert</i>
+										<!-- When a description is more than 14 characters, show the first 14
+										followed by three dots (cont) -->
+										[[ project.project_name.substring(0, 14) ]][[project.project_name.length > 14 ? "...": ""]]
+									</a>
+									<div class="word-wrap">
+										[[ project.project_desc.substring(0, 14) ]][[project.project_desc.length > 14 ? "...": ""]]
+									</div>
 								</div>
+								<div class="card-reveal">
+						      <span class="card-title grey-text text-darken-4"><i class="material-icons right">close</i>Actions</span>
+						      <div class="fixed-action-btn horizontal" style="bottom: 45px; right: 24px;">
+								   	<a class="btn-floating btn-small btn-flat black">
+									   	<i class="fa fa-list" style="font-size: 17px;"></i>
+									  </a>
+									  <ul>
+								   		<li><a class="btn-floating btn-small btn-flat red" ng-click="openDeleteModal(project.project_id, 'organisational')"><i class="material-icons">delete</i></a></li>
+								   		<li><a class="btn-floating btn-small btn-flat blue" ng-click="openEditProjectModal(project.project_id, project.owner, 'organisational')"><i class="material-icons">edit</i></a></li>
+								   	</ul>
+								  </div>
+						   	</div>
 							</div>
-							<div class="card-reveal">
-					      		<span class="card-title grey-text text-darken-4"><i class="material-icons right">close</i>Actions</span>
-					      		<div class="fixed-action-btn horizontal" style="bottom: 45px; right: 24px;">
-							    	<a class="btn-floating btn-small btn-flat black">
-								      	<i class="fa fa-list" style="font-size: 17px;"></i>
-								    </a>
-								    <ul>
-							      		<li><a class="btn-floating btn-small btn-flat red" ng-click="openDeleteModal(project.project_id, 'organisational')"><i class="material-icons">delete</i></a></li>
-							      		<li><a class="btn-floating btn-small btn-flat blue" ng-click="openEditProjectModal(project.project_id, project.owner, 'organisational')"><i class="material-icons">edit</i></a></li>
-							    	</ul>
-							  	</div>
-					   		</div>
 						</div>
 					</div>
+					<!-- Add organisational Project div -->
 					<div class="col s12 m4 l3 add-project">
 						<a href="#organisationalProjectModal" class="modal-trigger" ng-click="getAdminAssociatedOrgs()">
 							<div  class="card valign-wrapper">
@@ -95,6 +107,8 @@
 						<a href="#">view all</a>
 					</div>
 				</div>
+
+				<!-- Other projects view -->
 				<div class="col s12">
 					<h5>Other Projects</h5>
 					<div class="col s12 m4 l3" ng-repeat="project in other_projects">

--- a/public/templates/limber/projects.html
+++ b/public/templates/limber/projects.html
@@ -81,7 +81,7 @@
 						</div>
 					</div>
 					<div class="col s12 m4 l3 add-project">
-						<a href="#organisationalProjectModal" class="modal-trigger" ng-click="getAssociatedOrgs()">
+						<a href="#organisationalProjectModal" class="modal-trigger" ng-click="getAdminAssociatedOrgs()">
 							<div  class="card valign-wrapper">
 								<div class="card-content valign">
 									<span>


### PR DESCRIPTION
### What does this PR do?
-  This PR is an improvement of the projects dashboard view that classifies organisational projects on a **per organisation** basis.
### Description of the task to be completed?
-  The task at hand involved designing the project dashboard view to display projects in a per organisation basis when the user is working on more than one organisational project from different organisations
### How should this be manually tested?
-  The user can ensure membership into more than one organisation and also ensure participation in projects from different organisations
### Any background context you want to provide?
-  The controller uses the scope variable **`$scope.orgProjectClassifier`** that is initialised to an empty object. This object is then used to map **org_id: projects** in a **key: value** manner. The decision was made to use this technique because a normal scope variable would simply list **all projects** for **each and every organisation** in which the user is a member.
### What are the relevant pivotal tracker stories?

ID #112311313  - **Creating and managing projects on dashboard**
### Screenshot

<img width="1033" alt="screen shot 2016-03-22 at 17 17 44" src="https://cloud.githubusercontent.com/assets/13940255/13954477/f80750f4-f051-11e5-9955-af22fa785634.png">
### Questions
-  As the user becomes involved in more and more projects, how will we display just enough without cluttering the projects view?
